### PR TITLE
feat :add unique miniboss per location index

### DIFF
--- a/supabase/migrations/20260530125235_add_miniboss_location_unique_index.sql
+++ b/supabase/migrations/20260530125235_add_miniboss_location_unique_index.sql
@@ -1,0 +1,3 @@
+create unique index "Tasks_one_miniboss_per_location"
+on "public"."Tasks" ("locationId")
+where "isMiniBoss" is true;


### PR DESCRIPTION
## What changed

Added a Supabase migration that creates a partial unique index on `public.Tasks(locationId)` for rows where `isMiniBoss` is true.

## Why

This enforces that each location can have at most one miniboss task while allowing any number of regular tasks.

## Impact

Inserts or updates that would create a second miniboss for the same location will now fail at the database level.

## Validation

Created a new migration file containing only the index definition.